### PR TITLE
Update elixir example to use :crypto:mac/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Base64.encode64(OpenSSL::HMAC.digest('sha256', key, message))
 key = 'the shared secret key here'
 message = 'the message to hash here'
 
-signature = :crypto.hmac(:sha256, key, message)
+signature = :crypto.mac(:hmac, :sha256, key, message)
 
 # to lowercase hexits
 Base.encode16(signature, case: :lower)


### PR DESCRIPTION
`:crypto:hmac/3` is deprecated and removed since `Erlang/OTP` 24. `Erlang/OTP` 26 gives the following error

```
** (UndefinedFunctionError) function :crypto.hmac/3 is undefined or private, use :crypto:mac/4 instead
```

Output will be same like other/previous examples

```elixir
as hexit: 4643978965ffcec6e6d73b36a39ae43ceb15f7ef8131b8307862ebc560e7f988
as base64: RkOXiWX/zsbm1zs2o5rkPOsV9++BMbgweGLrxWDn+Yg=
```